### PR TITLE
Fixed aspect ratio

### DIFF
--- a/YoutubeOpenGL 10 - Specular Maps/Camera.cpp
+++ b/YoutubeOpenGL 10 - Specular Maps/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 11 - Types of Light/Camera.cpp
+++ b/YoutubeOpenGL 11 - Types of Light/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 12 - Mesh Class/Camera.cpp
+++ b/YoutubeOpenGL 12 - Mesh Class/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 13 - Model Loading/Camera.cpp
+++ b/YoutubeOpenGL 13 - Model Loading/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 14 - Depth Buffer/Camera.cpp
+++ b/YoutubeOpenGL 14 - Depth Buffer/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 15 - Stencil Buffer/Camera.cpp
+++ b/YoutubeOpenGL 15 - Stencil Buffer/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 16 - Face Culling & FPS Counter/Camera.cpp
+++ b/YoutubeOpenGL 16 - Face Culling & FPS Counter/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;

--- a/YoutubeOpenGL 7 - Going 3D/Main.cpp
+++ b/YoutubeOpenGL 7 - Going 3D/Main.cpp
@@ -154,7 +154,7 @@ int main()
 		// Assigns different transformations to each matrix
 		model = glm::rotate(model, glm::radians(rotation), glm::vec3(0.0f, 1.0f, 0.0f));
 		view = glm::translate(view, glm::vec3(0.0f, -0.5f, -2.0f));
-		proj = glm::perspective(glm::radians(45.0f), (float)(width / height), 0.1f, 100.0f);
+		proj = glm::perspective(glm::radians(45.0f), (float)width / height, 0.1f, 100.0f);
 
 		// Outputs the matrices into the Vertex Shader
 		int modelLoc = glGetUniformLocation(shaderProgram.ID, "model");

--- a/YoutubeOpenGL 8 - Camera/Camera.cpp
+++ b/YoutubeOpenGL 8 - Camera/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::Matrix(float FOVdeg, float nearPlane, float farPlane, Shader& shade
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Exports the camera matrix to the Vertex Shader
 	glUniformMatrix4fv(glGetUniformLocation(shader.ID, uniform), 1, GL_FALSE, glm::value_ptr(projection * view));

--- a/YoutubeOpenGL 9 - Lighting/Camera.cpp
+++ b/YoutubeOpenGL 9 - Lighting/Camera.cpp
@@ -18,7 +18,7 @@ void Camera::updateMatrix(float FOVdeg, float nearPlane, float farPlane)
 	// Makes camera look in the right direction from the right position
 	view = glm::lookAt(Position, Position + Orientation, Up);
 	// Adds perspective to the scene
-	projection = glm::perspective(glm::radians(FOVdeg), (float)(width / height), nearPlane, farPlane);
+	projection = glm::perspective(glm::radians(FOVdeg), (float)width / height, nearPlane, farPlane);
 
 	// Sets new camera matrix
 	cameraMatrix = projection * view;


### PR DESCRIPTION
Hello, thanks for this great tutorial on OpenGL! It's a pretty easy-to-follow series, and it made me like C++ more too. There is, however, an issue with the code you wrote for the camera.

[This line](https://github.com/VictorGordan/opengl-tutorials/blob/main/YoutubeOpenGL%2016%20-%20Face%20Culling%20%26%20FPS%20Counter/Camera.cpp#L21) divides int width by int height and converts the result to float. This causes the aspect ratio to be rounded. This isn't noticeable with the 800x800 resolution your tutorial uses, but when the resolution is set to, say, 1280x720, the issue becomes really apparent. This pull request should fix this in every tutorial since Going 3D.