### PR TITLE
Proposed fix to standardise glTF coordinate system with OpenGL.

### DIFF
--- a/YoutubeOpenGL 13 - Model Loading/default.vert
+++ b/YoutubeOpenGL 13 - Model Loading/default.vert
@@ -20,7 +20,6 @@ out vec3 color;
 out vec2 texCoord;
 
 
-
 // Imports the camera matrix
 uniform mat4 camMatrix;
 // Imports the transformation matrices
@@ -29,7 +28,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +42,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 14 - Depth Buffer/default.vert
+++ b/YoutubeOpenGL 14 - Depth Buffer/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 15 - Stencil Buffer/default.vert
+++ b/YoutubeOpenGL 15 - Stencil Buffer/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 16 - Face Culling & FPS Counter/default.vert
+++ b/YoutubeOpenGL 16 - Face Culling & FPS Counter/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 17 - Transparency & Blending/default.vert
+++ b/YoutubeOpenGL 17 - Transparency & Blending/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 18 - Framebuffer & Post-processing/default.vert
+++ b/YoutubeOpenGL 18 - Framebuffer & Post-processing/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 19 - Cubemaps & Skyboxes/default.vert
+++ b/YoutubeOpenGL 19 - Cubemaps & Skyboxes/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 20 - Geometry Shader/default.vert
+++ b/YoutubeOpenGL 20 - Geometry Shader/default.vert
@@ -28,12 +28,16 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	gl_Position = model * translation * rotation * scale * vec4(aPos, 1.0f);
 	data_out.Normal = aNormal;
 	data_out.color = aColor;
-	data_out.texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
+	data_out.texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	data_out.projection = camMatrix;
 }

--- a/YoutubeOpenGL 21 - Instancing (starting code)/default.vert
+++ b/YoutubeOpenGL 21 - Instancing (starting code)/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 21 - Instancing/default.vert
+++ b/YoutubeOpenGL 21 - Instancing/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 22 - Anti-Aliasing/default.vert
+++ b/YoutubeOpenGL 22 - Anti-Aliasing/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 24 - Gamma Correction/default.vert
+++ b/YoutubeOpenGL 24 - Gamma Correction/default.vert
@@ -29,7 +29,11 @@ uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
 
-
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 void main()
 {
 	// calculates current position
@@ -39,8 +43,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
-	
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 25 - Shadow Maps (Directional Lights)/default.vert
+++ b/YoutubeOpenGL 25 - Shadow Maps (Directional Lights)/default.vert
@@ -30,9 +30,14 @@ uniform mat4 model;
 uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
+
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 // Imports the light matrix
 uniform mat4 lightProjection;
-
 
 void main()
 {
@@ -43,10 +48,9 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Calculates the position of the light fragment for the fragment shader
 	fragPosLight = lightProjection * vec4(crntPos, 1.0f);
-	
 	// Outputs the positions/coordinates of all vertices
 	gl_Position = camMatrix * vec4(crntPos, 1.0);
 }

--- a/YoutubeOpenGL 26 - Shadow Maps (Spotlights & Point Lights)/default.vert
+++ b/YoutubeOpenGL 26 - Shadow Maps (Spotlights & Point Lights)/default.vert
@@ -30,6 +30,12 @@ uniform mat4 model;
 uniform mat4 translation;
 uniform mat4 rotation;
 uniform mat4 scale;
+
+// translation on the y-axis by -1.0
+// then mirror on the x-axis
+const mat3 coordinateCorrectionMatrix = mat3(vec3(1.0, 0.0, 0.0),
+                                             vec3(0.0,-1.0, 0.0),
+                                             vec3(0.0, 1.0, 1.0));
 // Imports the light matrix
 uniform mat4 lightProjection;
 
@@ -43,7 +49,7 @@ void main()
 	// Assigns the colors from the Vertex Data to "color"
 	color = aColor;
 	// Assigns the texture coordinates from the Vertex Data to "texCoord"
-	texCoord = mat2(0.0, -1.0, 1.0, 0.0) * aTex;
+	texCoord = vec2(coordinateCorrectionMatrix * vec3(aTex, 1.0));
 	// Calculates the position of the light fragment for the fragment shader
 	fragPosLight = lightProjection * vec4(crntPos, 1.0f);
 	


### PR DESCRIPTION
[As you can see glTF standardises the origin of texture coordinates at the top left of the image ](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#texture-data-overview:~:text=The%20origin%20of%20the%20texture%20coordinates%20(0%2C%200)%20corresponds%20to%20the%20upper%20left%20corner%20of%20a%20texture%20image.%20This%20is%20illustrated%20in%20the%20following%20figure%2C%20where%20the%20respective%20coordinates%20are%20shown%20for%20all%20four%20corners%20of%20a%20normalized%20texture%20space%3A), whereas OpenGL uses a bottom left origin.
There may be a way to configure OpenGL to set the origin of texture coordinates to the top left, but the proposed changes include a matrix transformation which fixes this error within the specified y-range of [0.0, 1.0] for texture coordinates. 

However, it runs in the vertex shader and therefor is expensive and not an ideal solution. 
I will work on a program to either alter the information on load, in the glTF file or memory. 

The best solution may be to write an image processor which mirrors the image files along y = 0.5,
which will only need to be run once after images are stored in the filestructure.
(Just flips all the images on the y-axis)
This will save all compute time on the user end and no extra memory is needed.

(P.S Thanks for your brilliant tutorial series, you've really helped me get started and passionate with graphics programming!)