### PR TITLE
Fixed bug from using the ++ operator in Model.cpp

### DIFF
--- a/YoutubeOpenGL 13 - Model Loading/Model.cpp
+++ b/YoutubeOpenGL 13 - Model Loading/Model.cpp
@@ -167,9 +167,9 @@ std::vector<float> Model::getFloats(json accessor)
 	// Go over all the bytes in the data at the correct place using the properties from above
 	unsigned int beginningOfData = byteOffset + accByteOffset;
 	unsigned int lengthOfData = count * 4 * numPerVert;
-	for (unsigned int i = beginningOfData; i < beginningOfData + lengthOfData; i)
+	for (unsigned int i = beginningOfData; i < beginningOfData + lengthOfData; i += 4)
 	{
-		unsigned char bytes[] = { data[i++], data[i++], data[i++], data[i++] };
+		unsigned char bytes[] = { data[i], data[i + 1], data[i + 2], data[i + 3] };
 		float value;
 		std::memcpy(&value, bytes, sizeof(float));
 		floatVec.push_back(value);
@@ -196,9 +196,9 @@ std::vector<GLuint> Model::getIndices(json accessor)
 	unsigned int beginningOfData = byteOffset + accByteOffset;
 	if (componentType == 5125)
 	{
-		for (unsigned int i = beginningOfData; i < byteOffset + accByteOffset + count * 4; i)
+		for (unsigned int i = beginningOfData; i < byteOffset + accByteOffset + count * 4; i += 4)
 		{
-			unsigned char bytes[] = { data[i++], data[i++], data[i++], data[i++] };
+			unsigned char bytes[] = { data[i], data[i + 1], data[i + 2], data[i + 3] };
 			unsigned int value;
 			std::memcpy(&value, bytes, sizeof(unsigned int));
 			indices.push_back((GLuint)value);
@@ -206,9 +206,9 @@ std::vector<GLuint> Model::getIndices(json accessor)
 	}
 	else if (componentType == 5123)
 	{
-		for (unsigned int i = beginningOfData; i < byteOffset + accByteOffset + count * 2; i)
+		for (unsigned int i = beginningOfData; i < byteOffset + accByteOffset + count * 2; i += 2)
 		{
-			unsigned char bytes[] = { data[i++], data[i++] };
+			unsigned char bytes[] = { data[i], data[i + 1] };
 			unsigned short value;
 			std::memcpy(&value, bytes, sizeof(unsigned short));
 			indices.push_back((GLuint)value);
@@ -216,9 +216,9 @@ std::vector<GLuint> Model::getIndices(json accessor)
 	}
 	else if (componentType == 5122)
 	{
-		for (unsigned int i = beginningOfData; i < byteOffset + accByteOffset + count * 2; i)
+		for (unsigned int i = beginningOfData; i < byteOffset + accByteOffset + count * 2; i += 2)
 		{
-			unsigned char bytes[] = { data[i++], data[i++] };
+			unsigned char bytes[] = { data[i], data[i + 1] };
 			short value;
 			std::memcpy(&value, bytes, sizeof(short));
 			indices.push_back((GLuint)value);
@@ -304,28 +304,49 @@ std::vector<Vertex> Model::assembleVertices
 
 std::vector<glm::vec2> Model::groupFloatsVec2(std::vector<float> floatVec)
 {
+	const unsigned int floatsPerVector = 2;
+	
 	std::vector<glm::vec2> vectors;
-	for (int i = 0; i < floatVec.size(); i)
+	for (unsigned int i = 0; i < floatVec.size(); i += floatsPerVector)
 	{
-		vectors.push_back(glm::vec2(floatVec[i++], floatVec[i++]));
+		vectors.push_back(glm::vec2(0, 0));
+
+		for (unsigned int j = 0; j < floatsPerVector; j++)
+		{
+			vectors.back()[j] = floatVec[i + j];
+		}
 	}
 	return vectors;
 }
 std::vector<glm::vec3> Model::groupFloatsVec3(std::vector<float> floatVec)
 {
+	const unsigned int floatsPerVector = 3;
+
 	std::vector<glm::vec3> vectors;
-	for (int i = 0; i < floatVec.size(); i)
+	for (unsigned int i = 0; i < floatVec.size(); i += floatsPerVector)
 	{
-		vectors.push_back(glm::vec3(floatVec[i++], floatVec[i++], floatVec[i++]));
+		vectors.push_back(glm::vec3(0, 0, 0));
+
+		for (unsigned int j = 0; j < floatsPerVector; j++)
+		{
+			vectors.back()[j] = floatVec[i + j];
+		}
 	}
 	return vectors;
 }
 std::vector<glm::vec4> Model::groupFloatsVec4(std::vector<float> floatVec)
 {
+	const unsigned int floatsPerVector = 4;
+
 	std::vector<glm::vec4> vectors;
-	for (int i = 0; i < floatVec.size(); i)
+	for (unsigned int i = 0; i < floatVec.size(); i += floatsPerVector)
 	{
-		vectors.push_back(glm::vec4(floatVec[i++], floatVec[i++], floatVec[i++], floatVec[i++]));
+		vectors.push_back(glm::vec4(0, 0, 0, 0));
+
+		for (unsigned int j = 0; j < floatsPerVector; j++)
+		{
+			vectors.back()[j] = floatVec[i + j];
+		}
 	}
 	return vectors;
 }


### PR DESCRIPTION
There was a bug with the functions in the Model.cpp file that used the ++ operator to create vectors / arrays.

I've now fixed that bug in the folder corresponding to the 13th episode of the tutorial series, but I don't know how to automatically fix this for all successive episodes. If anyone could help me I would be able to fix it for all tutorial episodes.